### PR TITLE
Updates setup.py and added snippets to let users input _params from a yaml file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+dist/
+build/
+*.egg
+.python-version
+.env
+.venv/

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
@@ -15,10 +14,7 @@ except ImportError:
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
-init_string = open(os.path.join(dir_path, 'src', 'baygaud', '__init__.py')).read()
-VERS = r"^__version__ = ['\"]([^'\"]*)['\"]"
-mo = re.search(VERS, init_string, re.M)
-__version__ = mo.group(1)
+init_string = open(os.path.join(dir_path, 'src','__init__.py')).read()
 
 try:
     import pypandoc
@@ -29,19 +25,69 @@ try:
 except ImportError:
     long_description = open('README.md').read()
 
- 
 setup(
     name                = 'baygaud',
     version             = '1.0.0',
     description         = 'profile decomposition tool',
     author              = 'Se-Heon Oh',
     author_email        = 'seheon.oh@sejong.ac.kr',
-    url                 = 'https://github.com/seheon-oh/baygaud',
-    packages            = ["baygaud"],
+    url                 = 'https://github.com/seheon-oh/baygaud-PI',
+    packages            = ["src"],
     keywords            = ['HI spectral line decomposition', 'nested sampling'],
     python_requires     = '>=3',
+    install_requires     = [
+        "aiosignal==1.3.1",
+        "astropy==5.2.1",
+        "attrs==22.2.0",
+        "casa-formats-io==0.2.1",
+        "certifi==2022.12.7",
+        "charset-normalizer==3.0.1",
+        "click==8.1.3",
+        "cloudpickle==2.2.1",
+        "contourpy==1.0.7",
+        "cycler==0.11.0",
+        "dask==2023.1.0",
+        "distlib==0.3.6",
+        "dynesty==2.0.3",
+        "filelock==3.9.0",
+        "fitsio==1.1.8",
+        "fonttools==4.38.0",
+        "frozenlist==1.3.3",
+        "fsspec==2023.1.0",
+        "grpcio==1.51.1",
+        "idna==3.4",
+        "joblib==1.2.0",
+        "jsonschema==4.17.3",
+        "kiwisolver==1.4.4",
+        "llvmlite==0.39.1",
+        "locket==1.0.0",
+        "matplotlib==3.6.3",
+        "msgpack==1.0.4",
+        "numba==0.56.4",
+        "numpy==1.23.5",
+        "packaging==23.0",
+        "partd==1.3.0",
+        "Pillow==9.4.0",
+        "platformdirs==2.6.2",
+        "protobuf==4.21.12",
+        "psutil==5.9.4",
+        "pyerfa==2.0.0.1",
+        "pyparsing==3.0.9",
+        "pyrsistent==0.19.3",
+        "python-dateutil==2.8.2",
+        "PyYAML==6.0",
+        "radio-beam==0.3.4",
+        "ray==2.2.0",
+        "requests==2.28.2",
+        "scipy==1.10.0",
+        "six==1.16.0",
+        "spectral-cube==0.6.0",
+        "tk==0.1.0",
+        "toolz==0.12.0",
+        "urllib3==1.26.14",
+        "virtualenv==20.17.1"
+        ],
     package_data        = {"": ["README.md"]},
-    package_dir			= {'': 'src/'},
     include_package_data=True,
     zip_safe            = False,
     classifiers         = [
@@ -52,31 +98,5 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-    ],
-=======
-from setuptools import setup, find_packages
-
-with open("README.md", "r") as readme:
-    long_description = readme.read()
-
-setup(
-    name="baygaud_PI",
-    version="1.0.0",
-    author="Se-Heon Oh",
-    author_email="seheon.oh@sejong.ac.kr",
-    description="HI spectral line pofile decomposition based on bayesisn nested sampling",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-#    url="<package_url>",
-    packages=find_packages(),
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-    ],
-    install_requires=[
-    ],
-
-    python_requires=">=3.6",
->>>>>>> .
-)
+    ]
+    )

--- a/setup.py
+++ b/setup.py
@@ -98,5 +98,11 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-    ]
-    )
+    ],
+    entry_points={
+        'console_scripts': [
+            'baygaud=src.baygaud:main',
+            'baygaud_classify=src.baygaud_classify:main',
+        ],
+    },
+)

--- a/src/_baygaud_params.py
+++ b/src/_baygaud_params.py
@@ -11,6 +11,8 @@
 
 import sys
 import numpy as np
+import yaml
+
 
 #  ______________________________________________________  #
 # [______________________________________________________] #
@@ -31,183 +33,192 @@ global nchannels
 # [______________________________________________________] #
 # [ baygaud parameters
 # _______________________________________________________  #
-_params = {
-#+++++++++++++++++++++++++++++++++
-# directories
-# baygaud main
-'main_baygaud':'/home/seheon/research/code/_python/baygaud_py/baygaud_PI/src',  # <---- UPDATE HERE
 
-# working directory where the input data cube is
-'wdir':'/home/seheon/research/code/_python/baygaud_py/baygaud_PI/demo/test_cube',  # <---- UPDATE HERE
+def read_configfile(configfile):
+    with open(configfile, "r") as file:
+        _params = yaml.safe_load(file)
+    return _params
 
-# output directory
-'_segdir':'baygaud_segs_output',
-'_combdir':'baygaud_combined',
+def default_params():
+    _params = {
+    #+++++++++++++++++++++++++++++++++
+    # directories
+    # baygaud main
+    'main_baygaud':'/home/seheon/research/code/_python/baygaud_py/baygaud_PI/src',  # <---- UPDATE HERE
 
-#+++++++++++++++++++++++++++++++++
-# input data cube
-'input_datacube':'ngc2403.regrid.testcube.0.fits',  # <---- UPDATE HERE
-#+++++++++++++++++++++++++++++++++
-# 2D mask available?
-# 2D mask with signals
-'_cube_mask':'N', # Y(if available) or N(if not)  # <---- UPDATE HERE
-# cube_mask 2D map: 2d fits (if not available, put blank)
-'_cube_mask_2d':'2403_mosaic_5kms_r05_HI_mwfilt_mask-2d.fits',  # <---- UPDATE HERE
+    # working directory where the input data cube is
+    'wdir':'/home/seheon/research/code/_python/baygaud_py/baygaud_PI/demo/test_cube',  # <---- UPDATE HERE
 
-#+++++++++++++++++++++++++++++++++
-# init
-'naxis1':0,
-'naxis2':0,
-'naxis3':0,
-'cdelt1':0,
-'cdelt2':0,
-'cdelt3':0,
-'vel_min':0, # km/s
-'vel_max':0, # km/s
-'_rms_med':0,
-'_bg_med':0,
-#+++++++++++++++++++++++++++++++++
+    # output directory
+    '_segdir':'baygaud_segs_output',
+    '_combdir':'baygaud_combined',
 
-# District to be fitted
-'naxis1_s0':5,  # <---- UPDATE HERE
-'naxis1_e0':35, # <---- UPDATE HERE
-'naxis2_s0':5,  # <---- UPDATE HERE
-'naxis2_e0':35, # <---- UPDATE HERE
+    #+++++++++++++++++++++++++++++++++
+    # input data cube
+    'input_datacube':'ngc2403.regrid.testcube.0.fits',  # <---- UPDATE HERE
+    #+++++++++++++++++++++++++++++++++
+    # 2D mask available?
+    # 2D mask with signals
+    '_cube_mask':'N', # Y(if available) or N(if not)  # <---- UPDATE HERE
+    # cube_mask 2D map: 2d fits (if not available, put blank)
+    '_cube_mask_2d':'2403_mosaic_5kms_r05_HI_mwfilt_mask-2d.fits',  # <---- UPDATE HERE
 
-# Number of steps to sample for deriving the backround rms
-# Derive the background rms values of nsteps_x_rms * nsteps_y_rms line profiles 
-# at the grids (X, Y) starting from (naxis1_s0, naxis1_e0) in steps of x_gab and y_gab below,
-# --> x_gab = (naxis1_e0 - naxis1_s0) / nsteps_x_rms 
-# --> y_gab = (naxis2_e0 - naxis2_s0) / nsteps_y_rms 
-# The median value of nsteps_x_rms * nsteps_y_rms line profiles is derived and used for peak S/N measurements of the line profiles processed (BUT more accurate background rms values will be derived from the bayesian fits in the course of the processing)
-'nsteps_x_rms':3, # <---- UPDATE HERE
-'nsteps_y_rms':3, # <---- UPDATE HERE
+    #+++++++++++++++++++++++++++++++++
+    # init
+    'naxis1':0,
+    'naxis2':0,
+    'naxis3':0,
+    'cdelt1':0,
+    'cdelt2':0,
+    'cdelt3':0,
+    'vel_min':0, # km/s
+    'vel_max':0, # km/s
+    '_rms_med':0,
+    '_bg_med':0,
+    #+++++++++++++++++++++++++++++++++
 
-#  ______________________________________________________  #
-# [______________________________________________________] #
-# [ dynesty parameters
-# _______________________________________________________  #
-'_dynesty_class_':'static', # (recommended)
-#'_dynesty_class_':'dynamic', # or static
+    # District to be fitted
+    'naxis1_s0':5,  # <---- UPDATE HERE
+    'naxis1_e0':35, # <---- UPDATE HERE
+    'naxis2_s0':5,  # <---- UPDATE HERE
+    'naxis2_e0':35, # <---- UPDATE HERE
 
-'nlive':100,
-#'sample':'auto', # or auto
-#'sample':'unif', # or auto
-'sample':'rwalk', # or auto
-#'sample':'slice', # or auto
-#'sample':'rslice', # or auto
-'dlogz':0.1,
-'maxiter':999999,
-'maxcall':999999,
-'update_interval':2.0, # ===> 2.0 x nlilve
-'vol_dec':0.2,
-'vol_check':2,
-'facc':0.5,
-'fmove':0.9,
-'walks':25,
-'rwalk':100,
-'max_move':100,
-'bound':'multi', # or 'single' for unimodal  :: if it complains about sampling efficiency, 'multi' is recommended..
+    # Number of steps to sample for deriving the backround rms
+    # Derive the background rms values of nsteps_x_rms * nsteps_y_rms line profiles 
+    # at the grids (X, Y) starting from (naxis1_s0, naxis1_e0) in steps of x_gab and y_gab below,
+    # --> x_gab = (naxis1_e0 - naxis1_s0) / nsteps_x_rms 
+    # --> y_gab = (naxis2_e0 - naxis2_s0) / nsteps_y_rms 
+    # The median value of nsteps_x_rms * nsteps_y_rms line profiles is derived and used for peak S/N measurements of the line profiles processed (BUT more accurate background rms values will be derived from the bayesian fits in the course of the processing)
+    'nsteps_x_rms':3, # <---- UPDATE HERE
+    'nsteps_y_rms':3, # <---- UPDATE HERE
 
+    #  ______________________________________________________  #
+    # [______________________________________________________] #
+    # [ dynesty parameters
+    # _______________________________________________________  #
+    '_dynesty_class_':'static', # (recommended)
+    #'_dynesty_class_':'dynamic', # or static
 
-#  ______________________________________________________  #
-# [______________________________________________________] #
-# [ classification parameters
-# _______________________________________________________  #
-'bayes_factor_limit':100, # <---- UPDATE HERE
-#'hanning_window_pre_sgfit':5,
-#'hanning_window_ngfit':1,
-'max_ngauss':3, # maximum number of Gaussian components : for initial baygaud run (non-recoverble)  # <---- UPDATE HERE
-'mom0_nrms_limit':3, # only profiles with peak fluxes > mom0_nrms_limit * rms + bg are used for computing mom0 : this is for deriving integrated S/N (for initial baygaud run - non-recoverble) # <---- UPDATE HERE
-'peak_sn_pass_for_ng_opt':3, # count Gaussians > peak_sn_pass_for_ng_opt (recoverble) # <---- UPDATE HERE
-'peak_sn_limit':2, # for initial baygaud run : do profile-decomposition for profiles only with > peak_sn_limit (for initial baygaud run: non-recoverable) # <---- UPDATE HERE
-'int_sn_limit':4.0, # for initial baygaud run : do profile-decomposition for profiles only with > peak_sn_limit (for initial baygaud run: non-recoverable) # <---- UPDATE HERE
-# _____________________________________  #
-# bulk motion
-# _____________________________________  #
-# bulk model dir (if not available, put blank)
-'_bulk_model_dir':'/home/seheon/research/mhongoose/ngc2403/things_model_vf/',  # <---- UPDATE HERE
-# bulk motion extraction toggle
-'_bulk_extraction':'N', # Y or N  # <---- UPDATE HERE
-# bulk motion reference velocity field: 2d fits (if not available, put blank)
-'_bulk_ref_vf':'ngc2403.bulk.vf.model.fits',  # <---- UPDATE HERE
-# bulk motion velocity difference limit: 2d fits (e.g., velocity dispersion map recommended)
-# <-- you can use the baygaud fitting result, e.g., sgfit.G3_1.2.fits
-'_bulk_delv_limit':'sgfit.G5_1.2.fits',  # <---- UPDATE HERE
-# bulk motion velocity difference limit factor: this value is multiplied to the bulk_delv_limit map
-'_bulk_delv_limit_factor':0.3,
-
-#  ______________________________________________________  #
-# [______________________________________________________] #
-# [ profile parameters : for _baygaud_classify.py
-# _______________________________________________________  #
-# 1. global kinematics  # <---- UPDATE HERE
-'vlos_lower':0, # km/s
-'vlos_upper':400, # km/s
-'vdisp_lower':5, # km/s
-'vdisp_upper':999, # km/s
-
-# _______________________________________________________  #
-# 2. kinematically cool components  # <---- UPDATE HERE
-'vlos_lower_cool':0, # km/s
-'vlos_upper_cool':400, # km/s
-'vdisp_lower_cool':5, # km/s
-'vdisp_upper_cool':12, # km/s
-
-# _______________________________________________________  #
-# 3. kinematically warm components  # <---- UPDATE HERE
-'vlos_lower_warm':0, # km/s
-'vlos_upper_warm':400, # km/s
-'vdisp_lower_warm':12, # km/s
-'vdisp_upper_warm':40, # km/s
-
-# _______________________________________________________  #
-# 4. kinematically hot components  # <---- UPDATE HERE
-'vlos_lower_hot':0, # km/s
-'vlos_upper_hot':400, # km/s
-'vdisp_lower_hot':40, # km/s
-'vdisp_upper_hot':999, # km/s
-
-# _______________________________________________________  #
-# 5. Check a profile <-- put a pixel coordinate (i, j) that you'd like to check
-'_i0':20, # x-pixel
-'_j0':20, # y-pixel
+    'nlive':100,
+    #'sample':'auto', # or auto
+    #'sample':'unif', # or auto
+    'sample':'rwalk', # or auto
+    #'sample':'slice', # or auto
+    #'sample':'rslice', # or auto
+    'dlogz':0.1,
+    'maxiter':999999,
+    'maxcall':999999,
+    'update_interval':2.0, # ===> 2.0 x nlilve
+    'vol_dec':0.2,
+    'vol_check':2,
+    'facc':0.5,
+    'fmove':0.9,
+    'walks':25,
+    'rwalk':100,
+    'max_move':100,
+    'bound':'multi', # or 'single' for unimodal  :: if it complains about sampling efficiency, 'multi' is recommended..
 
 
-#  ______________________________________________________  #
-# [______________________________________________________] #
-# [ priors
-# _______________________________________________________  #
-# parameters for the first 2nd gaussian fit : put a wide x range
-# x
-'x_lowerbound_gfit':0.1,
-'x_upperbound_gfit':0.9,
-# _______________________________________________________  #
-# parameters for the current and subsequent N-Gaussian fits
-'nsigma_prior_range_gfit':3.0, # for the N-gaussians in the N+1 gaussian fit
-# sigma
-'sigma_prior_lowerbound_factor':0.2,
-'sigma_prior_upperbound_factor':2.0,
-# bg
-'bg_prior_lowerbound_factor':0.2,
-'bg_prior_upperbound_factor':2.0,
-# x
-'x_prior_lowerbound_factor':5.0, # --> X_min - lowerbound_factor * STD_max
-'x_prior_upperbound_factor':5.0, # --> X_max + upperbound_factor * STD_max
-# std
-'std_prior_lowerbound_factor':0.1,
-'std_prior_upperbound_factor':3.0,
-# p
-'p_prior_lowerbound_factor':0.05,
-'p_prior_upperbound_factor':1.0,
+    #  ______________________________________________________  #
+    # [______________________________________________________] #
+    # [ classification parameters
+    # _______________________________________________________  #
+    'bayes_factor_limit':100, # <---- UPDATE HERE
+    #'hanning_window_pre_sgfit':5,
+    #'hanning_window_ngfit':1,
+    'max_ngauss':3, # maximum number of Gaussian components : for initial baygaud run (non-recoverble)  # <---- UPDATE HERE
+    'mom0_nrms_limit':3, # only profiles with peak fluxes > mom0_nrms_limit * rms + bg are used for computing mom0 : this is for deriving integrated S/N (for initial baygaud run - non-recoverble) # <---- UPDATE HERE
+    'peak_sn_pass_for_ng_opt':3, # count Gaussians > peak_sn_pass_for_ng_opt (recoverble) # <---- UPDATE HERE
+    'peak_sn_limit':2, # for initial baygaud run : do profile-decomposition for profiles only with > peak_sn_limit (for initial baygaud run: non-recoverable) # <---- UPDATE HERE
+    'int_sn_limit':4.0, # for initial baygaud run : do profile-decomposition for profiles only with > peak_sn_limit (for initial baygaud run: non-recoverable) # <---- UPDATE HERE
+    # _____________________________________  #
+    # bulk motion
+    # _____________________________________  #
+    # bulk model dir (if not available, put blank)
+    '_bulk_model_dir':'/home/seheon/research/mhongoose/ngc2403/things_model_vf/',  # <---- UPDATE HERE
+    # bulk motion extraction toggle
+    '_bulk_extraction':'N', # Y or N  # <---- UPDATE HERE
+    # bulk motion reference velocity field: 2d fits (if not available, put blank)
+    '_bulk_ref_vf':'ngc2403.bulk.vf.model.fits',  # <---- UPDATE HERE
+    # bulk motion velocity difference limit: 2d fits (e.g., velocity dispersion map recommended)
+    # <-- you can use the baygaud fitting result, e.g., sgfit.G3_1.2.fits
+    '_bulk_delv_limit':'sgfit.G5_1.2.fits',  # <---- UPDATE HERE
+    # bulk motion velocity difference limit factor: this value is multiplied to the bulk_delv_limit map
+    '_bulk_delv_limit_factor':0.3,
 
-#  ______________________________________________________  #
-# [______________________________________________________] #
-# parallellisation parameters
-'ncolm_per_core':'',
-'nsegments_nax2':'',
-'num_cpus':12,  # <---- UPDATE HERE
-}
+    #  ______________________________________________________  #
+    # [______________________________________________________] #
+    # [ profile parameters : for _baygaud_classify.py
+    # _______________________________________________________  #
+    # 1. global kinematics  # <---- UPDATE HERE
+    'vlos_lower':0, # km/s
+    'vlos_upper':400, # km/s
+    'vdisp_lower':5, # km/s
+    'vdisp_upper':999, # km/s
+
+    # _______________________________________________________  #
+    # 2. kinematically cool components  # <---- UPDATE HERE
+    'vlos_lower_cool':0, # km/s
+    'vlos_upper_cool':400, # km/s
+    'vdisp_lower_cool':5, # km/s
+    'vdisp_upper_cool':12, # km/s
+
+    # _______________________________________________________  #
+    # 3. kinematically warm components  # <---- UPDATE HERE
+    'vlos_lower_warm':0, # km/s
+    'vlos_upper_warm':400, # km/s
+    'vdisp_lower_warm':12, # km/s
+    'vdisp_upper_warm':40, # km/s
+
+    # _______________________________________________________  #
+    # 4. kinematically hot components  # <---- UPDATE HERE
+    'vlos_lower_hot':0, # km/s
+    'vlos_upper_hot':400, # km/s
+    'vdisp_lower_hot':40, # km/s
+    'vdisp_upper_hot':999, # km/s
+
+    # _______________________________________________________  #
+    # 5. Check a profile <-- put a pixel coordinate (i, j) that you'd like to check
+    '_i0':20, # x-pixel
+    '_j0':20, # y-pixel
+
+
+    #  ______________________________________________________  #
+    # [______________________________________________________] #
+    # [ priors
+    # _______________________________________________________  #
+    # parameters for the first 2nd gaussian fit : put a wide x range
+    # x
+    'x_lowerbound_gfit':0.1,
+    'x_upperbound_gfit':0.9,
+    # _______________________________________________________  #
+    # parameters for the current and subsequent N-Gaussian fits
+    'nsigma_prior_range_gfit':3.0, # for the N-gaussians in the N+1 gaussian fit
+    # sigma
+    'sigma_prior_lowerbound_factor':0.2,
+    'sigma_prior_upperbound_factor':2.0,
+    # bg
+    'bg_prior_lowerbound_factor':0.2,
+    'bg_prior_upperbound_factor':2.0,
+    # x
+    'x_prior_lowerbound_factor':5.0, # --> X_min - lowerbound_factor * STD_max
+    'x_prior_upperbound_factor':5.0, # --> X_max + upperbound_factor * STD_max
+    # std
+    'std_prior_lowerbound_factor':0.1,
+    'std_prior_upperbound_factor':3.0,
+    # p
+    'p_prior_lowerbound_factor':0.05,
+    'p_prior_upperbound_factor':1.0,
+
+    #  ______________________________________________________  #
+    # [______________________________________________________] #
+    # parallellisation parameters
+    'ncolm_per_core':'',
+    'nsegments_nax2':'',
+    'num_cpus':12,  # <---- UPDATE HERE
+    }
+    
+    return _params
 
 #-- END OF SUB-ROUTINE____________________________________#
 

--- a/src/baygaud.py
+++ b/src/baygaud.py
@@ -36,22 +36,22 @@ import ray
 # load baygaudpy modules
 #|-----------------------------------------|
 # _params.py
-from _baygaud_params import _params
+from src._baygaud_params import default_params, read_configfile
 global _x
 
 #|-----------------------------------------|
 # _dynesty_sampler.py
-from _dynesty_sampler import run_dynesty_sampler_uniform_priors
-from _dynesty_sampler import run_dynesty_sampler_optimal_priors
-from _dynesty_sampler import derive_rms_npoints
+from src._dynesty_sampler import run_dynesty_sampler_uniform_priors
+from src._dynesty_sampler import run_dynesty_sampler_optimal_priors
+from src._dynesty_sampler import derive_rms_npoints
 
 #|-----------------------------------------|
 # _fits_io.py
-from _fits_io import read_datacube, moment_analysis
+from src._fits_io import read_datacube, moment_analysis
 
 #|-----------------------------------------|
 # import make_dirs
-from _dirs_files import make_dirs
+from src._dirs_files import make_dirs
 
 #|-----------------------------------------|
 #|-----------------------------------------|
@@ -61,9 +61,16 @@ from _dirs_files import make_dirs
 
 #  _____________________________________________________________________________  #
 # [_____________________________________________________________________________] #
-if __name__ == "__main__":
+def main():
     # read the input datacube
     start = datetime.now()
+
+    if len(sys.argv) < 2:
+        ("WARNING: No configfile supplied, trying default values")
+        _params=default_params()
+    else:
+        configfile = sys.argv[1]
+        _params=read_configfile(configfile)
 
     _is = int(_params['naxis1_s0'])
     _ie = int(_params['naxis1_e0'])
@@ -157,4 +164,7 @@ if __name__ == "__main__":
     ray.shutdown()
     print("duration =", datetime.now() - start)
 #-- END OF SUB-ROUTINE____________________________________________________________#
+
+if __name__ == '__main__':
+    main()
 

--- a/src/baygaud_classify.py
+++ b/src/baygaud_classify.py
@@ -31,7 +31,7 @@ import itertools as itt
 
 #........................................ 
 # import make_dirs
-from _dirs_files import make_dirs
+from src._dirs_files import make_dirs
 
 #........................................ 
 # import for dynesty lines
@@ -52,12 +52,12 @@ import fitsio
 import astropy.units as u
 from astropy.io import fits
 from spectral_cube import SpectralCube
-from _baygaud_params import _params
+from src._baygaud_params import default_params, read_configfile
 
 
 #........................................ 
 # import _fits_io
-from _fits_io import update_header_cube_to_2d
+from src._fits_io import update_header_cube_to_2d
 
 #........................................ 
 # global parameters
@@ -419,8 +419,8 @@ def extract_maps_bulk(_fitsarray_gfit_results2, params, _output_dir, _kin_comp, 
     # ----------------------------------------------------------------------------------- #
     # CHECK POINT
     # ___________________________________________________________________________________ ###
-    i1 = _params['_i0']
-    j1 = _params['_j0']
+    i1 = params['_i0']
+    j1 = params['_j0']
 
     print("sn:", sn_ng_opt_bulk[j1, i1])
     print("x:", x_ng_opt_bulk[j1, i1])
@@ -1517,8 +1517,8 @@ def extract_maps_bulk_org(_fitsarray_gfit_results2, params, _output_dir, _kin_co
 
     #i1 = 156
     #j1 = 200
-    i1 = _params['_i0']
-    j1 = _params['_j0']
+    i1 = params['_i0']
+    j1 = params['_j0']
 
     print("sn:", sn_ng_opt_bulk[j1, i1])
     print("x:", x_ng_opt_bulk[j1, i1])
@@ -1966,8 +1966,8 @@ def extract_maps(_fitsarray_gfit_results2, params, _output_dir, _kin_comp, ng_op
 
     # sigma-flux : alternate to rms
 
-    i1 = _params['_i0']
-    j1 = _params['_j0']
+    i1 = params['_i0']
+    j1 = params['_j0']
     print("baygaud fitting results: profile (%d, %d)" % (i1, j1))
     print(_fitsarray_gfit_results2[:, j1, i1])
     #print('%f lower:%f upper:%f' % (_fitsarray_gfit_results2[3, 1, 1], _vdisp_lower, _vdisp_upper))
@@ -2181,8 +2181,8 @@ def extract_maps(_fitsarray_gfit_results2, params, _output_dir, _kin_comp, ng_op
 
     #i1 = 600
     #j1 = 468
-    i1 = _params['_i0']
-    j1 = _params['_j0']
+    i1 = params['_i0']
+    j1 = params['_j0']
     #print("")
     #print("sn:", sn_ng_opt[0, j1, i1], "x:", x_ng_opt[0, j1, i1], "std:", std_ng_opt[0, j1, i1], "ng:", ng_opt[j1, i1])
     #print("sn:", sn_ng_opt[1, j1, i1], "x:", x_ng_opt[1, j1, i1], "std:", std_ng_opt[1, j1, i1], "ng:", ng_opt[j1, i1])
@@ -3004,8 +3004,8 @@ def extract_maps_ngfit(_fitsarray_gfit_results2, params, _output_dir, _kin_comp,
 
     #i1 = 505
     #j1 = 512
-    i1 = _params['_i0']
-    j1 = _params['_j0']
+    i1 = params['_i0']
+    j1 = params['_j0']
     #print("")
     #print("sn:", sn_ng_opt[0, j1, i1], "x:", x_ng_opt[0, j1, i1], "std:", std_ng_opt[0, j1, i1], "bg:", bg_ng_opt[0, j1, i1],"ng:", ng_opt[j1, i1])
     #print("sn:", sn_ng_opt[1, j1, i1], "x:", x_ng_opt[1, j1, i1], "std:", std_ng_opt[1, j1, i1], "bg:", bg_ng_opt[1, j1, i1],"ng:", ng_opt[j1, i1])
@@ -7172,8 +7172,8 @@ def find_gx_opt_bf_snp(_fitsarray_gfit_results2, bevidences_sort, g_num_sort, bf
             # USE THIS PRINT COMMAND TO UNDERSTAND THE N_SN_PASS STRUCTURE
             #i1 = 600
             #j1 = 468
-            i1 = _params['_i0']
-            j1 = _params['_j0']
+            #i1 = _params['_i0']
+            #j1 = _params['_j0']
             #print("N_SN_PASS COMBINATION %s" % TF_flag, "loop_index_sn_pass:", loop_index_sn_pass, "gx_sn_pass:", gx_sn_pass[loop_index_sn_pass, j1, i1], flag_string)
             # ---------------------------------------------------------------
             loop_index_sn_pass += 1
@@ -7288,8 +7288,8 @@ def find_gx_opt_bf_snp(_fitsarray_gfit_results2, bevidences_sort, g_num_sort, bf
     # ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::: #
     #i1 = 600
     #j1 = 468
-    i1 = _params['_i0']
-    j1 = _params['_j0']
+    #i1 = _params['_i0']
+    #j1 = _params['_j0']
     #print("0:", gx_opt_bf_snp[0, j1, i1])
     #print("1:", gx_opt_bf_snp[1, j1, i1])
     #print("2:", gx_opt_bf_snp[2, j1, i1])
@@ -10161,7 +10161,7 @@ def g5_opt_bf(_fitsarray_gfit_results2, bevidences_sort, g_num_sort, sn_pass_ng_
 
 
 
-if __name__ == "__main__":
+def main():
 
     #  _____________________________________________________________________________  #
     # [_____________________________________________________________________________] #
@@ -10172,6 +10172,12 @@ if __name__ == "__main__":
     # start time
     _time_start = datetime.now()
 
+    if len(sys.argv) < 2:
+        ("WARNING: No configfile supplied, trying default values")
+        _params=default_params()
+    else:
+        configfile = sys.argv[1]
+        _params=read_configfile(configfile)
     #  _____________________________________________________________________________  #
     # [_____________________________________________________________________________] #
     print(" ____________________________________________")
@@ -10854,5 +10860,9 @@ if __name__ == "__main__":
     print("")
 
     #-----------------------------------------#
+
+if __name__ == '__main__':
+    main()
+
 #
 #-- END OF SUB-ROUTINE____________________________________________________________#


### PR DESCRIPTION
1) Fixed installation in setup.py
Users can now install baygaud-PI by following these steps:
Activate the python virtual environment
`git clone https://github.com/seheon-oh/baygaud-PI.git`
`cd baygaud-PI`
for developer installation (this installs the package in the same location to allow for changes to be reflected across the environment)
'pip install .'  or `python3 setup.py develop`
This will install the requirements as well. `pip install -r requirement.txt` can be avoided

2) Added entrypoints to setup.py and added functions to read a yaml file from the first argument or if not given assign default values from _baygaud_params.py
Once baygaud-PI has been installed in the virtual environment, it can be run straight from the terminal
`baygaud file.yml` followed by `baygaud_classify file.yml`
if a main() is added to baygaud_viewer, we can add an entry point to this as well.

3) Minor bug fixes to use `params` in some functions instead of `_params` since the argument is received at function definition is `params` and `_params` is no longer a global declaration
