### PR TITLE
Bug in velocity convention choosing logic

### DIFF
--- a/src/baygaud_pi/_fits_io.py
+++ b/src/baygaud_pi/_fits_io.py
@@ -78,13 +78,13 @@ def read_datacube(_params):
     _params['cdelt3'] = _cdelt3
 
     # Set spectral-unit / velocity convention for the cube
-    if _ctype3 != 'VOPT*':  # not optical
+    if 'VOPT' in _ctype3:
         cube = SpectralCube.read(_params['wdir'] + '/' + _params['input_datacube']) \
-                           .with_spectral_unit(u.m/u.s, velocity_convention='radio')  # in m/s
+                           .with_spectral_unit(u.m/u.s, velocity_convention='optical')  # in m/s
         _x = np.linspace(0, 1, _naxis3, dtype=np.float32)
     else:
         cube = SpectralCube.read(_params['wdir'] + '/' + _params['input_datacube']) \
-                           .with_spectral_unit(u.m/u.s, velocity_convention='optical')  # in m/s
+                           .with_spectral_unit(u.m/u.s, velocity_convention='radio')  # in m/s
         _x = np.linspace(0, 1, _naxis3, dtype=np.float32)
 
     # Store min/max velocity in km/s for convenience

--- a/src/baygaud_pi/_fits_io.py
+++ b/src/baygaud_pi/_fits_io.py
@@ -78,13 +78,13 @@ def read_datacube(_params):
     _params['cdelt3'] = _cdelt3
 
     # Set spectral-unit / velocity convention for the cube
-    if 'VOPT' in _ctype3:
+    if 'VOPT' not in _ctype3:
         cube = SpectralCube.read(_params['wdir'] + '/' + _params['input_datacube']) \
-                           .with_spectral_unit(u.m/u.s, velocity_convention='optical')  # in m/s
+                           .with_spectral_unit(u.m/u.s, velocity_convention='radio')  # in m/s
         _x = np.linspace(0, 1, _naxis3, dtype=np.float32)
     else:
         cube = SpectralCube.read(_params['wdir'] + '/' + _params['input_datacube']) \
-                           .with_spectral_unit(u.m/u.s, velocity_convention='radio')  # in m/s
+                           .with_spectral_unit(u.m/u.s, velocity_convention='optical')  # in m/s
         _x = np.linspace(0, 1, _naxis3, dtype=np.float32)
 
     # Store min/max velocity in km/s for convenience

--- a/src/baygaud_pi/baygaud_viewer.py
+++ b/src/baygaud_pi/baygaud_viewer.py
@@ -213,7 +213,7 @@ def read_ngfit_data(cube_fits=None, path_classified=None):
     with fits.open(window_params['cube_fits'], 'update') as hdu:
         _ctype3 = hdu[0].header['CTYPE3']
 
-    if _ctype3 != 'VOPT*':  # not optical
+    if 'VOPT' not in _ctype3:  # not optical
         _params['spectral_axis'] = SpectralCube.read(window_params['cube_fits']).with_spectral_unit(u.km/u.s, velocity_convention='radio').spectral_axis.value
     else:
         _params['spectral_axis'] = SpectralCube.read(window_params['cube_fits']).with_spectral_unit(u.km/u.s, velocity_convention='optical').spectral_axis.value


### PR DESCRIPTION
The current logic

`if _ctype3 != 'VOPT*':  # not optical`
is changed to 
`if 'VOPT' not in _ctype3:`

to work as intended.